### PR TITLE
fix(example): Lock Mongo to version 4.4.7

### DIFF
--- a/examples/Security-Role/productcatalog/templates/deployment-mongodb.yaml
+++ b/examples/Security-Role/productcatalog/templates/deployment-mongodb.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: {{.Release.Name}}-mongodb
-        image: mongo:latest
+        image: mongo:4.4.7
         ports:
         - name: {{.Release.Name}}-mongodb
           containerPort: 27017


### PR DESCRIPTION
Change manifest to use specific 4.4.7 mongo image

closes #27
