### PR TITLE
Added a custom .css to over-ride bullet-lists

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -1,0 +1,7 @@
+div.section ul {
+  list-style-type: disc !important;
+}
+div.section ul li {
+  display: list-item !important;
+  list-style: disc !important;
+}

--- a/doc/caDocs/Getting_started.md
+++ b/doc/caDocs/Getting_started.md
@@ -43,4 +43,4 @@ The ODA Technical Architecture & Components project is developing the formal spe
   * Introduce an TMFC019 Event Management component for the ODA and build an Operator using the YAML descriptor of components to set up event flows
 * Onboarding
   * Update the onboarding playbook on GitHub for new project members and interested observers
-  * Incorporate the latest materials eg demos and presentations from DTW 2022: [Whale Cloud Multi-cloud CNF deployment with the ODA Canvas](https://github.com/tmforum-oda/oda-ca-docs/blob/master/DTW_Presentations/Whale%20Cloud%20Multi-cloud%20CNF%20deployment%20with%20the%20ODA%20Canvas%20DTW-22.pptx?raw=true), [STL dPCC deployment with ODA Canvas](https://github.com/tmforum-oda/oda-ca-docs/blob/master/DTW_Presentations/STL%20dPCC%20deployment%20with%20ODA%20Canvas%20for%20DTW-22.pptx?raw=true)
+  * Incorporate the latest materials eg demos and presentations from DTW 2022

--- a/doc/caDocs/Playbook.md
+++ b/doc/caDocs/Playbook.md
@@ -40,9 +40,9 @@ Read [this presentation](https://github.com/tmforum-oda/oda-ca-docs/blob/master/
 * Early 2021 'Show & Tell' presentation introducing the Open Digital Lab environment and showcasing the deployment of commercial products onto the ODA reference Canvas, including the use of a 'Proxy Component' to integrate SaaS solutions: [video (1h 45 min)](https://video.ibm.com/channel/24077591/video/lf09c2)
 
 **Deploying Cloud Native Network Functions onto the ODA Canvas**
-
-* [Deployment of a CNF to an ODA Canvas running on two different cloud environments](https://github.com/tmforum-oda/oda-ca-docs/blob/master/DTW_Presentations/Whale%20Cloud%20Multi-cloud%20CNF%20deployment%20with%20the%20ODA%20Canvas%20DTW-22.pptx?raw=true). The Canvas standardizes the environment to enable plug-and-play deployment on different cloud platforms (by Whale Cloud)
-* [Deployment of PCRF (4G) and PCF (5G) onto the same ODA Canvas](https://github.com/tmforum-oda/oda-ca-docs/blob/master/DTW_Presentations/STL_Digital_BSS_Components_Architecture_with_ODA_Canvas.pptx?raw=true), making 4G->5G upgrades and other use cases easy to achieve (by Sterlite, demo video [here](https://www.tmforum.org/stl-oda-components/))
+ 
+* [Deployment of a CNF to an ODA Canvas running on two different cloud environments](https://github.com/tmforum-oda/oda-ca-docs/blob/master/DTW_Presentations/Whale%20Cloud%20Multi-cloud%20CNF%20deployment%20with%20the%20ODA%20Canvas%20DTW-22.pptx?raw=true). The Canvas standardizes the environment to enable plug-and-play deployment on different cloud platforms (by Whale Cloud, [3 min demo video here](https://iframe.dacast.com/vod/9292f2e21c51139fb9b2ffd6080ab1d6/ecb75692-55a4-2796-7f0a-710ad118b190))
+* [Deployment of PCRF (4G) and PCF (5G) onto the same ODA Canvas](https://github.com/tmforum-oda/oda-ca-docs/blob/master/DTW_Presentations/STL_Digital_BSS_Components_Architecture_with_ODA_Canvas.pdf?raw=true), making 4G->5G upgrades and other use cases easy to achieve (by Sterlite, [5 min demo video here)](https://www.tmforum.org/stl-oda-components/))
 
 **Current ODA-CA project members**
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -66,7 +66,9 @@ html_theme = 'sphinx_rtd_theme'
 html_static_path = ['_static']
 master_doc = 'index'
 autodoc_member_order = 'bysource'
-
+html_css_files = [
+    'css/custom.css'
+]
 print('Copying README and image files')
 import shutil
 import os


### PR DESCRIPTION
Closes #91 

Added a custom css:
```css
div.section ul {
  list-style-type: disc !important;
}
div.section ul li {
  display: list-item !important;
  list-style: disc !important;
}
```

Unordered lists within a section should use this instead of the theme.css (where the bullets are not shown).